### PR TITLE
Abstract for Precompiled contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,6 @@ name = "cosmwasm-vm"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std 1.1.6",
- "either",
  "env_logger 0.9.3",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,30 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
+name = "ahash"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -53,9 +64,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bech32"
@@ -113,9 +124,9 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -125,9 +136,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "core-foundation"
@@ -148,25 +159,12 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "cosmwasm-crypto"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28376836c7677e1ea6d6656a754582e88b91e544ce22fae42956d5fe5549a958"
-dependencies = [
- "digest 0.10.5",
- "ed25519-zebra",
- "k256",
- "rand_core 0.6.3",
- "thiserror",
-]
-
-[[package]]
-name = "cosmwasm-crypto"
-version = "1.1.5"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=7d288c23772d03e8cd666b76cb5bbdc5952721dd#7d288c23772d03e8cd666b76cb5bbdc5952721dd"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "thiserror",
 ]
 
@@ -175,26 +173,39 @@ name = "cosmwasm-crypto"
 version = "1.1.6"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=21351cc1ced863b9af7c8a69f923036bc919b3b1#21351cc1ced863b9af7c8a69f923036bc919b3b1"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227315dc11f0bb22a273d0c43d3ba8ef52041c42cf959f09045388a89c57e661"
+dependencies = [
+ "digest 0.10.6",
+ "ed25519-zebra",
+ "k256",
+ "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb69f4f7a8a4bce68c8fbd3646238fede1e77056e4ea31c5b6bfc37b709eec3"
+version = "1.1.6"
+source = "git+https://github.com/ComposableFi/cosmwasm?rev=21351cc1ced863b9af7c8a69f923036bc919b3b1#21351cc1ced863b9af7c8a69f923036bc919b3b1"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
-source = "git+https://github.com/ComposableFi/cosmwasm?rev=21351cc1ced863b9af7c8a69f923036bc919b3b1#21351cc1ced863b9af7c8a69f923036bc919b3b1"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fca30d51f7e5fbfa6440d8b10d7df0231bdf77e97fd3fe5d0cb79cc4822e50c"
 dependencies = [
  "syn",
 ]
@@ -227,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a227cfeb9a7152b26a354b1c990e930e962f75fd68f57ab5ae2ef888c8524292"
+checksum = "04135971e2c3b867eb793ca4e832543c077dbf72edaef7672699190f8fcdb619"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -240,32 +251,13 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3626cb42eef870de67f791e873711255325224d86f281bf628c42abd295f3a14"
+checksum = "a06c8f516a13ae481016aa35f0b5c4652459e8aee65b15b6fb51547a07cea5a0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cosmwasm-std"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bf9157d060abbc55152aeadcace799d03dc630575daa66604079a1206cb060"
-dependencies = [
- "base64",
- "cosmwasm-crypto 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cosmwasm-derive 1.1.5",
- "derivative",
- "forward_ref",
- "hex",
- "schemars",
- "serde",
- "serde-json-wasm",
- "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -287,12 +279,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-std"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d5a84d15cf7be17dc249a21588cdb0f7ef308907c50ce2723316a7d79c3dc"
+dependencies = [
+ "base64",
+ "cosmwasm-crypto 1.1.9",
+ "cosmwasm-derive 1.1.9",
+ "derivative",
+ "forward_ref",
+ "hex",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "cosmwasm-vm"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std 1.1.6",
  "either",
- "env_logger 0.9.0",
+ "env_logger 0.9.3",
  "log",
  "serde",
  "serde_json",
@@ -303,12 +314,12 @@ dependencies = [
 name = "cosmwasm-vm-wasmi"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-crypto 1.1.5 (git+https://github.com/ComposableFi/cosmwasm?rev=7d288c23772d03e8cd666b76cb5bbdc5952721dd)",
+ "cosmwasm-crypto 1.1.5",
  "cosmwasm-std 1.1.6",
  "cosmwasm-vm",
  "cw20-ics20",
  "either",
- "env_logger 0.9.0",
+ "env_logger 0.9.3",
  "hex",
  "log",
  "serde",
@@ -320,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -340,7 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -374,7 +385,7 @@ version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-storage-plus 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "cw-utils 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "schemars",
@@ -388,7 +399,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
 dependencies = [
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "schemars",
  "serde",
 ]
@@ -398,7 +409,7 @@ name = "cw-storage-plus"
 version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "schemars",
  "serde",
 ]
@@ -410,7 +421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw2 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
@@ -424,7 +435,7 @@ version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw2 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "schemars",
  "semver",
@@ -439,7 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-storage-plus 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
@@ -451,7 +462,7 @@ version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-storage-plus 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "schemars",
  "serde",
@@ -464,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45a8794a5dd33b66af34caee52a7beceb690856adcc1682b6e3db88b2cdee62"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-utils 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
@@ -476,7 +487,7 @@ version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-utils 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "schemars",
  "serde",
@@ -489,7 +500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61d826fa1084d026d0abdb54faa5956972efa3a9053473bfcefb5388960aab69"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-storage-plus 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-utils 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw2 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -506,7 +517,7 @@ version = "0.16.0"
 source = "git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f#53dc88fdb81888cbd3dae8742e7318b35d3d0c0f"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.1.5",
+ "cosmwasm-std 1.1.9",
  "cw-controllers",
  "cw-storage-plus 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
  "cw-utils 0.16.0 (git+https://github.com/CosmWasm/cw-plus?rev=53dc88fdb81888cbd3dae8742e7318b35d3d0c0f)",
@@ -520,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -550,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -561,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -579,24 +590,24 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
@@ -607,12 +618,12 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -629,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -689,7 +700,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -789,24 +800,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -844,6 +844,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -875,7 +878,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -986,37 +989,37 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -1053,21 +1056,21 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -1104,8 +1107,8 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1149,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -1170,19 +1173,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1192,9 +1195,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1224,9 +1227,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1277,18 +1280,18 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1298,17 +1301,14 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -1322,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -1396,32 +1396,31 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.3"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1487,15 +1486,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -1511,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1533,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1575,7 +1574,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1584,8 +1583,8 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
- "rand_core 0.6.3",
+ "digest 0.10.6",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1631,9 +1630,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1665,18 +1664,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1700,9 +1699,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a54aca0c15d014013256222ba0ebed095673f89345dd79119d912eb561b7a8"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1713,14 +1712,14 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1779,21 +1778,21 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1809,9 +1808,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -1824,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
@@ -1860,12 +1859,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1941,9 +1934,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.13.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0c17267a5ffd6ae3d897589460e21db1673c84fb7016b909c9691369a75ea"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
@@ -1989,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "42.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badcb03f976f983ff0daf294da9697be659442f61e6b0942bb37a2b6cbfe9dd4"
+checksum = "a2cbb59d4ac799842791fe7e806fa5dbbf6b5554d538e51cc8e176db6ff0ae34"
 dependencies = [
  "leb128",
  "memchr",
@@ -2001,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.44"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92f20b742ac527066c8414bc0637352661b68cab07ef42586cefaba71c965cf"
+checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
 dependencies = [
  "wast",
 ]
@@ -2051,30 +2044,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2085,21 +2065,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2109,21 +2077,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2136,12 +2092,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -17,7 +17,10 @@ use cosmwasm_vm::{
         },
         QueryResult,
     },
-    system::{cosmwasm_system_entrypoint, CosmwasmCallVM, CosmwasmCodeId, StargateCosmwasmCallVM},
+    system::{
+        cosmwasm_system_entrypoint, CosmwasmCallVM, CosmwasmCodeId, CosmwasmDynamicVM,
+        StargateCosmwasmCallVM,
+    },
     vm::{VmErrorOf, VmMessageCustomOf},
 };
 use cosmwasm_vm_wasmi::{WasmiBaseVM, WasmiVM};
@@ -435,7 +438,7 @@ pub trait ExecutionType {
         message: &[u8],
     ) -> Result<Self::Output<V>, VmError>
     where
-        WasmiVM<V>: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
+        WasmiVM<V>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
         VmErrorOf<WasmiVM<V>>: Into<VmError>;
 }
 
@@ -448,7 +451,7 @@ impl ExecutionType for Direct {
         message: &[u8],
     ) -> Result<Self::Output<V>, VmError>
     where
-        WasmiVM<V>: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
+        WasmiVM<V>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
         VmErrorOf<WasmiVM<V>>: Into<VmError>,
     {
         Ok(cosmwasm_call::<I, _>(vm, message)
@@ -470,7 +473,7 @@ impl ExecutionType for Dispatch {
         message: &[u8],
     ) -> Result<Self::Output<V>, VmError>
     where
-        WasmiVM<V>: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
+        WasmiVM<V>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
         VmErrorOf<WasmiVM<V>>: Into<VmError>,
     {
         cosmwasm_system_entrypoint::<I, _>(vm, message).map_err(Into::into)

--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -202,8 +202,8 @@ pub struct Context<'a, CH: CustomHandler, AH: AddressHandler> {
 }
 
 impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiContext for Context<'a, CH, AH> {
-    fn executing_module(&self) -> WasmiModule {
-        self.executing_module.clone()
+    fn executing_module(&self) -> Option<WasmiModule> {
+        Some(self.executing_module.clone())
     }
 }
 

--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -29,8 +29,9 @@ use cosmwasm_vm::{
     vm::{VMBase, VmErrorOf, VmGas, VmGasCheckpoint},
 };
 use cosmwasm_vm_wasmi::{
-    host_functions, new_wasmi_vm, WasmiHostFunction, WasmiHostFunctionIndex, WasmiImportResolver,
-    WasmiInput, WasmiModule, WasmiModuleExecutor, WasmiOutput, WasmiVM, WasmiVMError,
+    host_functions, new_wasmi_vm, WasmiContext, WasmiHost, WasmiHostFunction,
+    WasmiHostFunctionIndex, WasmiImportResolver, WasmiInput, WasmiModule, WasmiOutput, WasmiVM,
+    WasmiVMError,
 };
 use serde::de::DeserializeOwned;
 use wasm_instrument::gas_metering::Rules;
@@ -200,10 +201,13 @@ pub struct Context<'a, CH: CustomHandler, AH: AddressHandler> {
     pub state: &'a mut State<CH, AH>,
 }
 
-impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiModuleExecutor for Context<'a, CH, AH> {
+impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiContext for Context<'a, CH, AH> {
     fn executing_module(&self) -> WasmiModule {
         self.executing_module.clone()
     }
+}
+
+impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiHost<Self> for Context<'a, CH, AH> {
     fn host_function(&self, index: WasmiHostFunctionIndex) -> Option<&WasmiHostFunction<Self>> {
         self.host_functions.get(&index)
     }

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -14,7 +14,10 @@ use cosmwasm_vm::{
     },
     input::Input,
     memory::PointerOf,
-    system::{self, CosmwasmCallVM, CosmwasmCodeId, CosmwasmContractMeta, StargateCosmwasmCallVM, CosmwasmDynamicVM},
+    system::{
+        self, CosmwasmCallVM, CosmwasmCodeId, CosmwasmContractMeta, CosmwasmDynamicVM,
+        StargateCosmwasmCallVM,
+    },
     vm::{VmErrorOf, VmInputOf, VmMessageCustomOf},
 };
 use cosmwasm_vm_wasmi::{host_functions, new_wasmi_vm, WasmiBaseVM, WasmiImportResolver, WasmiVM};
@@ -256,7 +259,8 @@ where
         message: &[u8],
     ) -> Result<E::Output<Context<'a, CH, AH>>, VmError>
     where
-        WasmiVM<Context<'a, CH, AH>>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
+        WasmiVM<Context<'a, CH, AH>>:
+            CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
     {
         self.gas = Gas::new(gas);
         let mut vm = create_vm(self, env, info);

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -14,7 +14,7 @@ use cosmwasm_vm::{
     },
     input::Input,
     memory::PointerOf,
-    system::{self, CosmwasmCallVM, CosmwasmCodeId, CosmwasmContractMeta, StargateCosmwasmCallVM},
+    system::{self, CosmwasmCallVM, CosmwasmCodeId, CosmwasmContractMeta, StargateCosmwasmCallVM, CosmwasmDynamicVM},
     vm::{VmErrorOf, VmInputOf, VmMessageCustomOf},
 };
 use cosmwasm_vm_wasmi::{host_functions, new_wasmi_vm, WasmiBaseVM, WasmiImportResolver, WasmiVM};
@@ -85,7 +85,7 @@ where
         message: &[u8],
     ) -> Result<E::Output<VM>, VmError>
     where
-        WasmiVM<VM>: CosmwasmCallVM<I> + StargateCosmwasmCallVM;
+        WasmiVM<VM>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM;
 
     /// Common endpoint for any other direct endpoint like `ibc_channel_open`
     fn do_direct<I>(
@@ -256,7 +256,7 @@ where
         message: &[u8],
     ) -> Result<E::Output<Context<'a, CH, AH>>, VmError>
     where
-        WasmiVM<Context<'a, CH, AH>>: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
+        WasmiVM<Context<'a, CH, AH>>: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
     {
         self.gas = Gas::new(gas);
         let mut vm = create_vm(self, env, info);

--- a/vm-wasmi/Cargo.toml
+++ b/vm-wasmi/Cargo.toml
@@ -18,7 +18,7 @@ ibc3 = ["cosmwasm-vm/ibc3"]
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
-either = { version = "1.6", default-features = false }
+either = { version = "1.8", default-features = false }
 log = { version = "0.4", default-features = false }
 wasmi = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b", default-features = false }
 wasm-instrument = { version = "0.2", default-features = false }

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -165,6 +165,7 @@ where
 pub trait WasmiContext {
     fn executing_module(&self) -> WasmiModule;
 }
+
 pub trait WasmiHost<T: Sized + VMBase> {
     fn host_function(&self, index: WasmiHostFunctionIndex) -> Option<&WasmiHostFunction<T>>;
 }

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -132,7 +132,9 @@ impl Display for WasmiVMError {
     }
 }
 
-pub trait WasmiBaseVM = WasmiModuleExecutor
+pub trait WasmiBaseVM = Sized
+    + WasmiHost<Self>
+    + WasmiContext
     + VMBase<
         ContractMeta = CosmwasmContractMeta<VmAddressOf<Self>>,
         StorageKey = Vec<u8>,
@@ -160,9 +162,11 @@ where
     ReadableMemoryErrorOf<Self>: From<MemoryReadError>,
     WritableMemoryErrorOf<Self>: From<MemoryWriteError>;
 
-pub trait WasmiModuleExecutor: Sized + VMBase {
+pub trait WasmiContext {
     fn executing_module(&self) -> WasmiModule;
-    fn host_function(&self, index: WasmiHostFunctionIndex) -> Option<&WasmiHostFunction<Self>>;
+}
+pub trait WasmiHost<T: Sized + VMBase> {
+    fn host_function(&self, index: WasmiHostFunctionIndex) -> Option<&WasmiHostFunction<T>>;
 }
 
 pub struct WasmiVM<T>(pub T);

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -201,8 +201,8 @@ struct SimpleWasmiVM<'a> {
 }
 
 impl<'a> WasmiContext for SimpleWasmiVM<'a> {
-    fn executing_module(&self) -> WasmiModule {
-        self.executing_module.clone()
+    fn executing_module(&self) -> Option<WasmiModule> {
+        Some(self.executing_module.clone())
     }
 }
 

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -1,12 +1,14 @@
 extern crate std;
 
+use crate::WasmiHost;
+
 use super::{
     code_gen, format, host_functions, new_wasmi_vm, vec, BTreeMap, CanResume, CanonicalAddr,
     ContractInfoResponse, CosmwasmQueryResult, Debug, Display, ExecutorError, Has, MemoryReadError,
     MemoryWriteError, Pointable, QueryResult, ReadWriteMemory, ReadableMemory, Reply, String,
     SystemError, SystemResult, Transactional, VMBase, Vec, VmErrorOf, VmGas, VmGasCheckpoint,
-    WasmiHostFunction, WasmiHostFunctionIndex, WasmiImportResolver, WasmiInput, WasmiModule,
-    WasmiModuleExecutor, WasmiOutput, WasmiVM, WasmiVMError, WritableMemory,
+    WasmiContext, WasmiHostFunction, WasmiHostFunctionIndex, WasmiImportResolver, WasmiInput,
+    WasmiModule, WasmiOutput, WasmiVM, WasmiVMError, WritableMemory,
 };
 use alloc::string::ToString;
 use core::{assert_matches::assert_matches, num::NonZeroU32, str::FromStr};
@@ -198,10 +200,13 @@ struct SimpleWasmiVM<'a> {
     extension: &'a mut SimpleWasmiVMExtension,
 }
 
-impl<'a> WasmiModuleExecutor for SimpleWasmiVM<'a> {
+impl<'a> WasmiContext for SimpleWasmiVM<'a> {
     fn executing_module(&self) -> WasmiModule {
         self.executing_module.clone()
     }
+}
+
+impl<'a> WasmiHost<Self> for SimpleWasmiVM<'a> {
     fn host_function(&self, index: WasmiHostFunctionIndex) -> Option<&WasmiHostFunction<Self>> {
         self.host_functions.get(&index)
     }

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -1242,7 +1242,7 @@ fn test_hook() {
             sender.0
         )
         .as_bytes(),
-        |vm, msg| cosmwasm_call::<InstantiateCall, WasmiVM<SimpleWasmiVM>>(vm, msg),
+        |vm, msg| cosmwasm_call::<InstantiateCall, WasmiVM<SimpleWasmiVM>>(vm, msg).map(Into::into),
     )
     .unwrap();
     let r = cosmwasm_system_entrypoint_hook::<ExecuteCall, WasmiVM<SimpleWasmiVM>>(
@@ -1254,7 +1254,7 @@ fn test_hook() {
               }
             }"#
         .as_bytes(),
-        |_, _| Ok(ExecuteResult(ContractResult::Err("Bro".into()))),
+        |_, _| Ok(ContractResult::Err("Bro".into())),
     );
     assert_eq!(
         r,

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -19,7 +19,7 @@ ibc3 = ["cosmwasm-std/ibc3"]
 cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351cc1ced863b9af7c8a69f923036bc919b3b1", default-features = false, features = [
   "iterator",
 ] }
-either = { version = "1.6", default-features = false }
+either = { version = "1.8", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -19,7 +19,6 @@ ibc3 = ["cosmwasm-std/ibc3"]
 cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351cc1ced863b9af7c8a69f923036bc919b3b1", default-features = false, features = [
   "iterator",
 ] }
-either = { version = "1.8", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -181,6 +181,16 @@ impl ReadLimit for QueryResult {
         read_limits::RESULT_QUERY
     }
 }
+impl From<CosmwasmQueryResult> for QueryResult {
+    fn from(value: CosmwasmQueryResult) -> Self {
+        Self(value)
+    }
+}
+impl From<QueryResult> for CosmwasmQueryResult {
+    fn from(QueryResult(value): QueryResult) -> Self {
+        value
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ExecuteResult<T = Empty>(pub CosmwasmExecutionResult<T>);

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -163,6 +163,11 @@ impl<T> From<ReplyResult<T>> for ContractResult<Response<T>> {
         result
     }
 }
+impl<T> From<ContractResult<Response<T>>> for ReplyResult<T> {
+    fn from(value: ContractResult<Response<T>>) -> Self {
+        ReplyResult(value)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct QueryResult(pub CosmwasmQueryResult);
@@ -194,6 +199,11 @@ impl<T> From<ExecuteResult<T>> for ContractResult<Response<T>> {
         result
     }
 }
+impl<T> From<ContractResult<Response<T>>> for ExecuteResult<T> {
+    fn from(value: ContractResult<Response<T>>) -> Self {
+        ExecuteResult(value)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct InstantiateResult<T = Empty>(pub CosmwasmExecutionResult<T>);
@@ -212,6 +222,11 @@ impl<T> From<InstantiateResult<T>> for ContractResult<Response<T>> {
         result
     }
 }
+impl<T> From<ContractResult<Response<T>>> for InstantiateResult<T> {
+    fn from(value: ContractResult<Response<T>>) -> Self {
+        InstantiateResult(value)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MigrateResult<T = Empty>(pub CosmwasmExecutionResult<T>);
@@ -228,6 +243,11 @@ impl<T> ReadLimit for MigrateResult<T> {
 impl<T> From<MigrateResult<T>> for ContractResult<Response<T>> {
     fn from(MigrateResult(result): MigrateResult<T>) -> Self {
         result
+    }
+}
+impl<T> From<ContractResult<Response<T>>> for MigrateResult<T> {
+    fn from(value: ContractResult<Response<T>>) -> Self {
+        MigrateResult(value)
     }
 }
 
@@ -287,6 +307,19 @@ pub mod ibc {
             }
         }
     }
+    impl<T> From<ContractResult<Response<T>>> for IbcChannelConnectResult<T> {
+        fn from(value: ContractResult<Response<T>>) -> Self {
+            IbcChannelConnectResult(match value {
+                ContractResult::Ok(response) => ContractResult::Ok(
+                    IbcBasicResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events),
+                ),
+                ContractResult::Err(e) => ContractResult::Err(e),
+            })
+        }
+    }
 
     /// Response to the low level `ibc_channel_close` call.
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -318,6 +351,19 @@ pub mod ibc {
                 ),
                 ContractResult::Err(x) => ContractResult::Err(x),
             }
+        }
+    }
+    impl<T> From<ContractResult<Response<T>>> for IbcChannelCloseResult<T> {
+        fn from(value: ContractResult<Response<T>>) -> Self {
+            IbcChannelCloseResult(match value {
+                ContractResult::Ok(response) => ContractResult::Ok(
+                    IbcBasicResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events),
+                ),
+                ContractResult::Err(e) => ContractResult::Err(e),
+            })
         }
     }
 
@@ -355,6 +401,24 @@ pub mod ibc {
             }
         }
     }
+    impl<T> From<ContractResult<Response<T>>> for IbcPacketReceiveResult<T> {
+        fn from(value: ContractResult<Response<T>>) -> Self {
+            IbcPacketReceiveResult(match value {
+                ContractResult::Ok(response) => ContractResult::Ok(match response.data {
+                    Some(data) => IbcReceiveResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events)
+                        .set_ack(data),
+                    None => IbcReceiveResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events),
+                }),
+                ContractResult::Err(e) => ContractResult::Err(e),
+            })
+        }
+    }
 
     /// Response to the low level `ibc_packet_ack` call.
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -388,6 +452,19 @@ pub mod ibc {
             }
         }
     }
+    impl<T> From<ContractResult<Response<T>>> for IbcPacketAckResult<T> {
+        fn from(value: ContractResult<Response<T>>) -> Self {
+            IbcPacketAckResult(match value {
+                ContractResult::Ok(response) => ContractResult::Ok(
+                    IbcBasicResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events),
+                ),
+                ContractResult::Err(e) => ContractResult::Err(e),
+            })
+        }
+    }
 
     /// Response to the low level `ibc_packet_timeout` call.
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -419,6 +496,19 @@ pub mod ibc {
                 ),
                 ContractResult::Err(x) => ContractResult::Err(x),
             }
+        }
+    }
+    impl<T> From<ContractResult<Response<T>>> for IbcPacketTimeoutResult<T> {
+        fn from(value: ContractResult<Response<T>>) -> Self {
+            IbcPacketTimeoutResult(match value {
+                ContractResult::Ok(response) => ContractResult::Ok(
+                    IbcBasicResponse::new()
+                        .add_submessages(response.messages)
+                        .add_attributes(response.attributes)
+                        .add_events(response.events),
+                ),
+                ContractResult::Err(e) => ContractResult::Err(e),
+            })
         }
     }
 

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -61,15 +61,15 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 // WasmModuleEventType is stored with any contract TX that returns non empty EventAttributes
-const WASM_MODULE_EVENT_TYPE: &str = "wasm";
+pub const WASM_MODULE_EVENT_TYPE: &str = "wasm";
 
 // CustomContractEventPrefix contracts can create custom events. To not mix them with other system events they got the `wasm-` prefix.
-const CUSTOM_CONTRACT_EVENT_PREFIX: &str = "wasm-";
+pub const CUSTOM_CONTRACT_EVENT_PREFIX: &str = "wasm-";
 
 // Minimum length of an event type
-const CUSTOM_CONTRACT_EVENT_TYPE_MIN_LENGTH: usize = 2;
+pub const CUSTOM_CONTRACT_EVENT_TYPE_MIN_LENGTH: usize = 2;
 
-const WASM_MODULE_EVENT_RESERVED_PREFIX: &str = "_";
+pub const WASM_MODULE_EVENT_RESERVED_PREFIX: &str = "_";
 
 #[allow(unused)]
 #[allow(clippy::module_name_repetitions)]

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -345,7 +345,8 @@ where
 pub trait CosmwasmCallVM<I> = CosmwasmBaseVM
 where
     I: Input + HasInfo + HasEvent,
-    OutputOf<I>: Into<ContractResult<Response<VmMessageCustomOf<Self>>>>;
+    OutputOf<I>: Into<ContractResult<Response<VmMessageCustomOf<Self>>>>
+        + From<ContractResult<Response<VmMessageCustomOf<Self>>>>;
 
 pub trait CosmwasmDynamicVM<I> = CosmwasmBaseVM
 where

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -405,14 +405,19 @@ where
     V: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
     M: Serialize,
 {
-    cosmwasm_system_entrypoint_serialize_hook(vm, message, |vm, msg| cosmwasm_call::<I, V>(vm, msg))
+    cosmwasm_system_entrypoint_serialize_hook(vm, message, |vm, msg| {
+        cosmwasm_call::<I, V>(vm, msg).map(Into::into)
+    })
 }
 
 /// Extra helper to dispatch a typed message, serializing on the go.
 pub fn cosmwasm_system_entrypoint_serialize_hook<I, V, M>(
     vm: &mut V,
     message: &M,
-    hook: impl FnOnce(&mut V, &[u8]) -> Result<<I as Input>::Output, VmErrorOf<V>>,
+    hook: impl FnOnce(
+        &mut V,
+        &[u8],
+    ) -> Result<ContractResult<Response<VmMessageCustomOf<V>>>, VmErrorOf<V>>,
 ) -> Result<(Option<Binary>, Vec<Event>), VmErrorOf<V>>
 where
     V: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
@@ -432,7 +437,9 @@ pub fn cosmwasm_system_entrypoint<I, V>(
 where
     V: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
 {
-    cosmwasm_system_entrypoint_hook(vm, message, |vm, msg| cosmwasm_call::<I, V>(vm, msg))
+    cosmwasm_system_entrypoint_hook(vm, message, |vm, msg| {
+        cosmwasm_call::<I, V>(vm, msg).map(Into::into)
+    })
 }
 
 /// High level dispatch for a `CosmWasm` VM.
@@ -443,7 +450,10 @@ where
 pub fn cosmwasm_system_entrypoint_hook<I, V>(
     vm: &mut V,
     message: &[u8],
-    hook: impl FnOnce(&mut V, &[u8]) -> Result<<I as Input>::Output, VmErrorOf<V>>,
+    hook: impl FnOnce(
+        &mut V,
+        &[u8],
+    ) -> Result<ContractResult<Response<VmMessageCustomOf<V>>>, VmErrorOf<V>>,
 ) -> Result<(Option<Binary>, Vec<Event>), VmErrorOf<V>>
 where
     V: CosmwasmCallVM<I> + StargateCosmwasmCallVM,
@@ -709,7 +719,7 @@ where
     V: CosmwasmCallVM<I> + CosmwasmDynamicVM<I> + StargateCosmwasmCallVM,
 {
     cosmwasm_system_run_hook(vm, message, event_handler, |vm, msg| {
-        cosmwasm_call::<I, V>(vm, msg)
+        cosmwasm_call::<I, V>(vm, msg).map(Into::into)
     })
 }
 
@@ -718,7 +728,10 @@ pub fn cosmwasm_system_run_hook<I, V>(
     vm: &mut V,
     message: &[u8],
     mut event_handler: &mut dyn FnMut(Event),
-    hook: impl FnOnce(&mut V, &[u8]) -> Result<<I as Input>::Output, VmErrorOf<V>>,
+    hook: impl FnOnce(
+        &mut V,
+        &[u8],
+    ) -> Result<ContractResult<Response<VmMessageCustomOf<V>>>, VmErrorOf<V>>,
 ) -> Result<Option<Binary>, VmErrorOf<V>>
 where
     V: CosmwasmCallVM<I> + StargateCosmwasmCallVM,

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -345,10 +345,7 @@ where
 pub trait CosmwasmCallVM<I> = CosmwasmBaseVM
 where
     I: Input + HasInfo + HasEvent,
-    OutputOf<I>: DeserializeOwned
-        + ReadLimit
-        + DeserializeLimit
-        + Into<ContractResult<Response<VmMessageCustomOf<Self>>>>;
+    OutputOf<I>: Into<ContractResult<Response<VmMessageCustomOf<Self>>>>;
 
 pub trait CosmwasmDynamicVM<I> = CosmwasmBaseVM
 where
@@ -371,7 +368,9 @@ where
             CosmwasmCallWithoutInfoInput<'x, PointerOf<Self>, MigrateCall<VmMessageCustomOf<Self>>>,
             Error = VmErrorOf<Self>,
         > + TryFrom<CosmwasmCallInput<'x, PointerOf<Self>, I>, Error = VmErrorOf<Self>>
-        + TryFrom<CosmwasmCallWithoutInfoInput<'x, PointerOf<Self>, I>, Error = VmErrorOf<Self>>;
+        + TryFrom<CosmwasmCallWithoutInfoInput<'x, PointerOf<Self>, I>, Error = VmErrorOf<Self>>,
+    I: Input + HasInfo + HasEvent,
+    OutputOf<I>: DeserializeOwned + ReadLimit + DeserializeLimit;
 
 #[cfg(feature = "stargate")]
 /// Extra constraints required by stargate enabled `CosmWasm` VM (a.k.a. IBC capable).


### PR DESCRIPTION
In this PR we further split the traits to allow for a more flexible handling of contract execution at impl level. This refactoring will allow us to implement a hardcoded type for precompiled contracts easily (for instance, implementing a pallet as a contract in Substrate)