### PR TITLE
feat(vm): fix audit report findings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /docs/orchestrate/book
 /target
 /result
+/.direnv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "cosmwasm-std 1.1.6",
  "env_logger 0.9.3",
  "log",
+ "num",
  "serde",
  "serde_json",
  "wat",
@@ -325,6 +326,7 @@ dependencies = [
  "serde_json",
  "wasm-instrument",
  "wasmi",
+ "wasmi-validation",
  "wat",
 ]
 
@@ -1129,6 +1131,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,12 +1155,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 

--- a/vm-wasmi/Cargo.toml
+++ b/vm-wasmi/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 either = { version = "1.8", default-features = false }
 log = { version = "0.4", default-features = false }
 wasmi = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b", default-features = false }
+wasmi-validation = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b", default-features = false }
 wasm-instrument = { version = "0.2", default-features = false }
 cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351cc1ced863b9af7c8a69f923036bc919b3b1", default-features = false, features = [
   "iterator",

--- a/vm-wasmi/src/code_gen.rs
+++ b/vm-wasmi/src/code_gen.rs
@@ -336,7 +336,8 @@ impl From<ModuleDefinition> for WasmModule {
             .global()
             .with_type(ValueType::I32)
             .mutable()
-            .init_expr(Instruction::I32Const(0))
+            // We don't want this to be zero since 0 is an invalid pointer
+            .init_expr(Instruction::I32Const(10))
             .build()
             // Export memory
             .export()

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -33,6 +33,8 @@
 extern crate alloc;
 
 pub mod code_gen;
+pub mod validation;
+pub mod version;
 
 #[cfg(test)]
 mod semantic;

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -771,6 +771,11 @@ impl<T: Has<U>, U> Has<U> for WasmiVM<T> {
     }
 }
 
+/// Create a wasm module out of `code` and `resolver`.
+///
+/// Note that validation is not done here since the implementors probably wouldn't want
+/// to do an expensive validation on each time they load the same code. So DO NOT forget
+/// to use `CodeValidation` to properly validate the wasm module.
 pub fn new_wasmi_vm<T>(
     resolver: &WasmiImportResolver<T>,
     code: &[u8],

--- a/vm-wasmi/src/validation.rs
+++ b/vm-wasmi/src/validation.rs
@@ -1,0 +1,283 @@
+use super::version::Export;
+use alloc::vec::Vec;
+use wasm_instrument::parity_wasm::elements::{
+    ExportSection, External, FunctionSection, ImportSection, Instruction, Internal, Module, Type,
+    TypeSection, ValueType,
+};
+use wasmi_validation::Validator;
+
+#[derive(Debug)]
+#[allow(clippy::module_name_repetitions)]
+pub enum ValidationError {
+    Validation(wasmi_validation::Error),
+    ExportMustBeAFunction(&'static str),
+    EntryPointPointToImport(&'static str),
+    ExportDoesNotExist(&'static str),
+    ExportWithoutSignature(&'static str),
+    ExportWithWrongSignature {
+        export_name: &'static str,
+        expected_signature: Vec<ValueType>,
+        actual_signature: Vec<ValueType>,
+    },
+    MissingMandatoryExport(&'static str),
+    CannotImportTable,
+    CannotImportGlobal,
+    CannotImportMemory,
+    ImportWithoutSignature,
+    ImportIsBanned(&'static str, &'static str),
+    MustDeclareOneInternalMemory,
+    MustDeclareOneTable,
+    TableExceedLimit,
+    BrTableExceedLimit,
+    GlobalsExceedLimit,
+    GlobalFloatingPoint,
+    LocalFloatingPoint,
+    ParamFloatingPoint,
+    FunctionParameterExceedLimit,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum ExportRequirement {
+    Mandatory,
+    Optional,
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeValidation<'a>(&'a Module);
+
+impl<'a> CodeValidation<'a> {
+    #[must_use]
+    pub fn new(module: &'a Module) -> Self {
+        CodeValidation(module)
+    }
+
+    /// Middleware function for `wasmi_validation::validate_module`
+    ///
+    /// * `input`: Custom input to validator
+    pub fn validate_module<V: Validator>(
+        self,
+        input: <V as Validator>::Input,
+    ) -> Result<Self, ValidationError> {
+        wasmi_validation::validate_module::<V>(self.0, input)
+            .map_err(ValidationError::Validation)?;
+        Ok(self)
+    }
+
+    /// Checks if the expected exports exist and correct.
+    ///
+    /// If the export is mandatory, then it has to be present in the wasm module it's signature must
+    /// be correct. In both cases, exports need to have the identical signatures as well.
+    pub fn validate_exports(self, expected_exports: &[Export]) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        let types = module
+            .type_section()
+            .map_or(Default::default(), TypeSection::types);
+        let export_entries = module
+            .export_section()
+            .map_or(Default::default(), ExportSection::entries);
+        let func_entries = module
+            .function_section()
+            .map_or(Default::default(), FunctionSection::entries);
+        let fn_space_offset = module
+            .import_section()
+            .map_or(Default::default(), ImportSection::entries)
+            .iter()
+            .filter(|entry| matches!(*entry.external(), External::Function(_)))
+            .count();
+        for (requirement, name, signature) in expected_exports {
+            match (
+                requirement,
+                export_entries.iter().find(|e| &e.field() == name),
+            ) {
+                (_, Some(export)) => {
+                    let fn_idx = match export.internal() {
+                        Internal::Function(ref fn_idx) => Ok(*fn_idx),
+                        _ => Err(ValidationError::ExportMustBeAFunction(name)),
+                    }?;
+                    #[allow(clippy::cast_possible_truncation)]
+                    let fn_idx = match fn_idx.checked_sub(fn_space_offset as u32) {
+                        Some(fn_idx) => Ok(fn_idx),
+                        None => Err(ValidationError::EntryPointPointToImport(name)),
+                    }?;
+                    let func_ty_idx = func_entries
+                        .get(fn_idx as usize)
+                        .ok_or(ValidationError::ExportDoesNotExist(name))?
+                        .type_ref();
+                    let Type::Function(ref func_ty) = types
+                        .get(func_ty_idx as usize)
+                        .ok_or(ValidationError::ExportWithoutSignature(name))?;
+                    if signature != &func_ty.params() {
+                        return Err(ValidationError::ExportWithWrongSignature {
+                            export_name: name,
+                            expected_signature: signature.to_vec(),
+                            actual_signature: func_ty.params().to_vec(),
+                        });
+                    }
+                }
+                (ExportRequirement::Mandatory, None) => {
+                    return Err(ValidationError::MissingMandatoryExport(name))
+                }
+                (ExportRequirement::Optional, None) => {}
+            }
+        }
+        Ok(self)
+    }
+
+    /// Check if the module imports the correct externals and avoids importing
+    /// the banned imports.
+    ///
+    /// Currently only functions are imported, so it will fail if any other
+    /// external is imported.
+    pub fn validate_imports(
+        self,
+        import_banlist: &[(&'static str, &'static str)],
+    ) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        let types = module
+            .type_section()
+            .map_or(Default::default(), TypeSection::types);
+        let import_entries = module
+            .import_section()
+            .map_or(Default::default(), ImportSection::entries);
+        for import in import_entries {
+            let type_idx = match import.external() {
+                External::Table(_) => Err(ValidationError::CannotImportTable),
+                External::Global(_) => Err(ValidationError::CannotImportGlobal),
+                External::Memory(_) => Err(ValidationError::CannotImportMemory),
+                External::Function(ref type_idx) => Ok(type_idx),
+            }?;
+            let import_name = import.field();
+            let import_module = import.module();
+            let Type::Function(_) = types
+                .get(*type_idx as usize)
+                .ok_or(ValidationError::ImportWithoutSignature)?;
+            if let Some((m, f)) = import_banlist
+                .iter()
+                .find(|(m, f)| m == &import_module && f == &import_name)
+            {
+                return Err(ValidationError::ImportIsBanned(m, f));
+            }
+        }
+        Ok(self)
+    }
+
+    /// Verify if the memory is setup correctly.
+    ///
+    /// Currently only a single memory section is supported.
+    pub fn validate_memory_limit(self) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if module
+            .memory_section()
+            .map_or(false, |ms| ms.entries().len() != 1)
+        {
+            Err(ValidationError::MustDeclareOneInternalMemory)
+        } else {
+            Ok(self)
+        }
+    }
+
+    /// Make sure that there is a table and the table's entries are smaller than the `limit`.
+    pub fn validate_table_size_limit(self, limit: u32) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if let Some(table_section) = module.table_section() {
+            if table_section.entries().len() > 1 {
+                return Err(ValidationError::MustDeclareOneTable);
+            }
+            if let Some(table_type) = table_section.entries().first() {
+                if table_type.limits().initial() > limit {
+                    return Err(ValidationError::TableExceedLimit);
+                }
+            }
+        }
+        Ok(self)
+    }
+
+    /// Make sure that the br table length doesn't exceed the `limit`.
+    pub fn validate_br_table_size_limit(self, limit: u32) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if let Some(code_section) = module.code_section() {
+            for instr in code_section
+                .bodies()
+                .iter()
+                .flat_map(|body| body.code().elements())
+            {
+                if let Instruction::BrTable(table) = instr {
+                    if table.table.len() > limit as usize {
+                        return Err(ValidationError::BrTableExceedLimit);
+                    }
+                }
+            }
+        };
+        Ok(self)
+    }
+
+    /// Make sure that the count of global variables don't exceed the `limit`.
+    pub fn validate_global_variable_limit(self, limit: u32) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if let Some(global_section) = module.global_section() {
+            if global_section.entries().len() > limit as usize {
+                return Err(ValidationError::GlobalsExceedLimit);
+            }
+        }
+        Ok(self)
+    }
+
+    /// Make sure that there is no floating types. Floating point types yield to undeterministic
+    /// wasm builds. That's why they are undesirable.
+    pub fn validate_no_floating_types(self) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if let Some(global_section) = module.global_section() {
+            for global in global_section.entries() {
+                match global.global_type().content_type() {
+                    ValueType::F32 | ValueType::F64 => {
+                        return Err(ValidationError::GlobalFloatingPoint)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(code_section) = module.code_section() {
+            for func_body in code_section.bodies() {
+                for local in func_body.locals() {
+                    match local.value_type() {
+                        ValueType::F32 | ValueType::F64 => {
+                            return Err(ValidationError::LocalFloatingPoint)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        if let Some(type_section) = module.type_section() {
+            for wasm_type in type_section.types() {
+                match wasm_type {
+                    Type::Function(func_type) => {
+                        let return_type = func_type.results().get(0);
+                        for value_type in func_type.params().iter().chain(return_type) {
+                            match value_type {
+                                ValueType::F32 | ValueType::F64 => {
+                                    return Err(ValidationError::ParamFloatingPoint)
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(self)
+    }
+
+    /// Make sure that the count of parameters in functions do not exceed the `limit`.
+    pub fn validate_parameter_limit(self, limit: u32) -> Result<Self, ValidationError> {
+        let CodeValidation(module) = self;
+        if let Some(type_section) = module.type_section() {
+            for Type::Function(func) in type_section.types() {
+                if func.params().len() > limit as usize {
+                    return Err(ValidationError::FunctionParameterExceedLimit);
+                }
+            }
+        }
+        Ok(self)
+    }
+}

--- a/vm-wasmi/src/version.rs
+++ b/vm-wasmi/src/version.rs
@@ -1,0 +1,120 @@
+use super::validation::ExportRequirement;
+use cosmwasm_vm::executor::{
+    ibc::{
+        IbcChannelCloseCall, IbcChannelConnectCall, IbcChannelOpenCall, IbcPacketAckCall,
+        IbcPacketReceiveCall, IbcPacketTimeoutCall,
+    },
+    AllocateCall, AsFunctionName, DeallocateCall, ExecuteCall, InstantiateCall, MigrateCall,
+    QueryCall, ReplyCall,
+};
+use wasm_instrument::parity_wasm::elements::ValueType;
+
+/// Requirement, Export name, Parameters
+pub type Export = (ExportRequirement, &'static str, &'static [ValueType]);
+
+pub trait Version {
+    /// `ENV_MODULE.ENV_GAS` function import should be injected by the instrumentor.
+    const ENV_MODULE: &'static str = "env";
+    const ENV_GAS: &'static str = "gas";
+    const EXPORTS: &'static [Export];
+    const IBC_EXPORTS: &'static [Export];
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct Version1x;
+
+impl Version for Version1x {
+    const EXPORTS: &'static [Export] = &[
+        // We support v1+
+        (
+            ExportRequirement::Mandatory,
+            // extern "C" fn interface_version_8() -> () {}
+            "interface_version_8",
+            &[],
+        ),
+        // Memory related exports.
+        (
+            ExportRequirement::Mandatory,
+            // extern "C" fn allocate(size: usize) -> u32;
+            AllocateCall::<()>::NAME,
+            &[ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            // extern "C" fn deallocate(pointer: u32);
+            DeallocateCall::<()>::NAME,
+            &[ValueType::I32],
+        ),
+        // Contract execution exports.
+        (
+            ExportRequirement::Mandatory,
+            // extern "C" fn instantiate(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32;
+            InstantiateCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Optional,
+            // extern "C" fn execute(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32;
+            ExecuteCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Optional,
+            // extern "C" fn query(env_ptr: u32, msg_ptr: u32) -> u32;
+            QueryCall::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Optional,
+            // extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32;
+            MigrateCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Optional,
+            // extern "C" fn reply(env_ptr: u32, msg_ptr: u32) -> u32;
+            ReplyCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+    ];
+
+    // IBC callbacks that a contract must export to be considered IBC capable:
+    // extern "C" fn ibc_channel_open(env_ptr: u32, msg_ptr: u32) -> u32;
+    // extern "C" fn ibc_channel_connect(env_ptr: u32, msg_ptr: u32) -> u32;
+    // extern "C" fn ibc_channel_close(env_ptr: u32, msg_ptr: u32) -> u32;
+    // extern "C" fn ibc_packet_receive(env_ptr: u32, msg_ptr: u32) -> u32;
+    // extern "C" fn ibc_packet_ack(env_ptr: u32, msg_ptr: u32) -> u32;
+    // extern "C" fn ibc_packet_timeout(env_ptr: u32, msg_ptr: u32) -> u32;
+    const IBC_EXPORTS: &'static [Export] = &[
+        (
+            ExportRequirement::Mandatory,
+            IbcChannelOpenCall::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            IbcChannelConnectCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            IbcChannelCloseCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            IbcPacketReceiveCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            IbcPacketAckCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+        (
+            ExportRequirement::Mandatory,
+            IbcPacketTimeoutCall::<()>::NAME,
+            &[ValueType::I32, ValueType::I32],
+        ),
+    ];
+}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -20,6 +20,7 @@ cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351c
   "iterator",
 ] }
 log = { version = "0.4", default-features = false }
+num = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -39,6 +39,7 @@ use crate::{
 use alloc::vec::Vec;
 use core::{fmt::Debug, marker::PhantomData};
 use cosmwasm_std::{Binary, ContractResult, Empty, Env, MessageInfo, QueryRequest, Response};
+use num::traits::Zero;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 pub mod read_limits {
@@ -832,6 +833,9 @@ where
     VmErrorOf<V>:
         From<ReadableMemoryErrorOf<V>> + From<WritableMemoryErrorOf<V>> + From<ExecutorError>,
 {
+    if destination.is_zero() {
+        return Err(ExecutorError::InvalidPointer.into());
+    }
     RawIntoRegion::try_from(Write(vm, destination, data))?;
     Ok(())
 }

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -645,6 +645,7 @@ where
                 contract_addr,
                 admin: new_admin,
             } => {
+                vm.addr_validate(&new_admin)??;
                 let new_admin = new_admin.try_into()?;
                 let vm_contract_addr = VmAddressOf::<V>::try_from(contract_addr)?;
                 update_admin::<V>(vm, &info.sender, vm_contract_addr, Some(new_admin))?;

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -645,7 +645,6 @@ where
                 contract_addr,
                 admin: new_admin,
             } => {
-                vm.addr_validate(&new_admin)??;
                 let new_admin = new_admin.try_into()?;
                 let vm_contract_addr = VmAddressOf::<V>::try_from(contract_addr)?;
                 update_admin::<V>(vm, &info.sender, vm_contract_addr, Some(new_admin))?;


### PR DESCRIPTION
This PR fixes the things that Halborn have found in their audit:
1. Moving code validation logic from `pallet-cosmwasm` to here so that implementors can use. The validation is not enforced for performance reasons though.
2. Verifying the `Region` that is returned from the wasm module.
3. Verifying the pointer that is returned by the `allocate` function.
4. Verifying the data size when using unsafe `core::slice::from_raw_parts(_mut)`
