### PR TITLE
XCVM-298, XCVM-297: Wasmi upgrade, `no_std` in orchestrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "async-trait"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,13 +224,16 @@ dependencies = [
  "base64",
  "bech32",
  "bs58",
- "cosmwasm-crypto 1.2.0",
  "cosmwasm-std 1.2.0",
  "cosmwasm-vm",
  "cosmwasm-vm-wasmi",
+ "ed25519-zebra",
  "env_logger 0.10.0",
  "hex",
+ "libsecp256k1",
  "log",
+ "rand_chacha",
+ "rand_core 0.6.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -364,6 +373,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -801,11 +820,32 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -998,6 +1038,54 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1227,6 +1315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1336,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1338,7 +1451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -1927,8 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi-validation"
-version = "0.4.1"
-source = "git+https://github.com/ComposableFi/wasmi?rev=cd8c0c775a1d197a35ff3d5c7d6cded3d476411b#cd8c0c775a1d197a35ff3d5c7d6cded3d476411b"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
 dependencies = [
  "parity-wasm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d1c97b30ae00ad9380eb1de4fa28651622ec80ece02bab625f45058e600416"
+checksum = "c8ad19edb5ccf561b5a01c9e37bd1ff38b2c2443c778aa2ff65e993205189c33"
 dependencies = [
  "spin",
  "wasmi_arena",
@@ -2049,26 +2055,27 @@ dependencies = [
 
 [[package]]
 name = "wasmi_arena"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5581c09dbb8d5c8b0b219c840db487d0ebc2decff86ab0f658bf7f598d0efc"
+checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
 
 [[package]]
 name = "wasmi_core"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd07f4aac41a8d5e5a7fabd8dc908fe9ba2182431ebaf968ef210aaf4fe9917e"
+checksum = "2a2bde97906bbc49ad61184db16e5c905e946e747f6febd09b583fc321d70af0"
 dependencies = [
  "downcast-rs",
  "libm",
  "num-traits",
+ "paste",
 ]
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.91.0"
+version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
 dependencies = [
  "indexmap-nostd",
 ]

--- a/orchestrate/Cargo.toml
+++ b/orchestrate/Cargo.toml
@@ -3,27 +3,34 @@ name = "cosmwasm-orchestrate"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["std"]
+std = ["reqwest", "cosmwasm-std/std"]
+
 [dependencies]
 cosmwasm-vm = { path = "../vm" }
 cosmwasm-vm-wasmi = { path = "../vm-wasmi" }
-cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "34af48221c90e6818fe341d6d5b15116dfeab671", features = [
+cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "34af48221c90e6818fe341d6d5b15116dfeab671", default-features = false, features = [
   "stargate",
   "ibc3",
-  "staking",
+  "staking", 
   "cosmwasm_1_2"
 ] }
-cosmwasm-crypto = { git = "https://github.com/ComposableFi/cosmwasm", rev = "34af48221c90e6818fe341d6d5b15116dfeab671" }
-serde_json = "1.0"
-serde = { version = "1.0", features = [ "derive" ] }
-wasmi = "0.22"
-wasm-instrument = "0.2"
+ed25519-zebra = { version = "3.1.0", default-features = false }
+libsecp256k1 = { version = "0.7.1", default-features = false, features = [ "hmac", "static-context" ] }
+serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
+serde = { version = "1.0", default-features = false, features = [ "derive", "alloc" ] }
+wasmi = { version = "0.22", default-features = false }
+wasm-instrument = { version = "0.2", default-features = false }
 log = "0.4"
-sha2 = "0.10"
-reqwest = "0.11"
-base64 = "0.13.1"
+sha2 = { version = "0.10", default-features = false }
+reqwest = { version = "0.11", optional = true }
+base64 = { version = "0.13.1", default-features = false }
 async-trait = "0.1.58"
-bech32 = "0.9.1"
-bs58 = "0.4.0"
+bech32 = { version = "0.9.1", default-features = false }
+bs58 = { version = "0.4.0", default-features = false, features = [ "alloc" ] }
+rand_core = { version = "0.6.4", default-features = false, features = [ "alloc" ] }
+rand_chacha = { version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.24", features = [ "rt", "macros", "rt-multi-thread" ] }

--- a/orchestrate/Cargo.toml
+++ b/orchestrate/Cargo.toml
@@ -20,7 +20,7 @@ ed25519-zebra = { version = "3.1.0", default-features = false }
 libsecp256k1 = { version = "0.7.1", default-features = false, features = [ "hmac", "static-context" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 serde = { version = "1.0", default-features = false, features = [ "derive", "alloc" ] }
-wasmi = { version = "0.22", default-features = false }
+wasmi = { version = "0.26", default-features = false }
 wasm-instrument = { version = "0.2", default-features = false }
 log = "0.4"
 sha2 = { version = "0.10", default-features = false }

--- a/orchestrate/README.md
+++ b/orchestrate/README.md
@@ -14,4 +14,4 @@ CosmWasm Orchestrate is a tool for simulating and testing CosmWasm contracts on 
 - **Flexible**: The framework is also very flexible and lets you define your own mechanism to handle custom messages, handle different address formats and even implement your own host functions and VM.
 
 
-To learn more, go to the [documentation](https://docs.composable.finance/products/cosmwasm-orchestrate).
+To learn more, go to the [documentation](https://docs.composable.finance/developer-guides/cosmwasm-orchestrate).

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -2,10 +2,10 @@ use crate::vm::{
     Account, AddressHandler, Context, CustomHandler, IbcChannelId, JunoAddressHandler, State,
     SubstrateAddressHandler, VmError, VmState, WasmAddressHandler,
 };
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, vec, vec::Vec};
 use core::marker::PhantomData;
 use cosmwasm_std::{
-    from_binary, Addr, Binary, BlockInfo, Coin, ContractInfo, Env, Event, IbcChannelConnectMsg,
+    Addr, Binary, BlockInfo, Coin, ContractInfo, Env, Event, IbcChannelConnectMsg,
     IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, MessageInfo,
     Timestamp, TransactionInfo,
 };
@@ -402,7 +402,7 @@ where
     ) -> Result<R, VmError> {
         let message = serde_json::to_vec(&message).map_err(|_| VmError::CannotSerialize)?;
         let QueryResult(value) = Self::query_raw(vm_state, env, &message)?;
-        from_binary::<R>(&value.into_result().map_err(VmError::Generic)?)
+        serde_json::from_slice::<R>(value.into_result().map_err(VmError::Generic)?.as_ref())
             .map_err(|_| VmError::CannotDeserialize)
     }
 

--- a/orchestrate/src/ibc.rs
+++ b/orchestrate/src/ibc.rs
@@ -2,6 +2,7 @@ use crate::{
     vm::{Account, AddressHandler, Context, CustomHandler, IbcState, State, VmError},
     Api as IApi, Direct, Dispatch,
 };
+use alloc::{format, string::String, vec::Vec};
 use cosmwasm_std::{
     Binary, Env, Event, Ibc3ChannelOpenResponse, IbcAcknowledgement, IbcChannel,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcEndpoint, IbcOrder, IbcPacketAckMsg,

--- a/orchestrate/src/lib.rs
+++ b/orchestrate/src/lib.rs
@@ -1,16 +1,19 @@
 #![feature(trait_alias)]
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 
 extern crate alloc;
 
 mod api;
 pub mod error;
+#[cfg(feature = "std")]
 pub mod fetcher;
 pub mod ibc;
 pub mod vm;
+#[cfg(feature = "std")]
 mod wasm_builder;
 
 pub use api::*;
 pub use cosmwasm_std;
+#[cfg(feature = "std")]
 pub use wasm_builder::*;

--- a/orchestrate/src/vm/account.rs
+++ b/orchestrate/src/vm/account.rs
@@ -1,5 +1,5 @@
 use super::{AddressHandler, VmError};
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::fmt::Display;
 use cosmwasm_std::{Addr, Binary, CanonicalAddr};
 use sha2::{Digest, Sha256};

--- a/orchestrate/src/vm/address.rs
+++ b/orchestrate/src/vm/address.rs
@@ -1,4 +1,5 @@
 use super::VmError;
+use alloc::{string::String, vec::Vec};
 use bech32::{self, FromBase32, ToBase32, Variant};
 use sha2::{Digest, Sha256};
 

--- a/orchestrate/src/vm/bank.rs
+++ b/orchestrate/src/vm/bank.rs
@@ -1,5 +1,5 @@
 use super::Account;
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use cosmwasm_std::Coin;
 
 pub type Denom = String;

--- a/orchestrate/src/vm/error.rs
+++ b/orchestrate/src/vm/error.rs
@@ -1,4 +1,5 @@
 use super::{bank, Account};
+use alloc::{format, string::String};
 use core::fmt::Display;
 use cosmwasm_vm::{
     executor::ExecutorError,

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -3,7 +3,12 @@ use super::{
     Account, AddressHandler, Context, CustomHandler, Db, ExecutionType, Gas, IbcChannelId,
     IbcState, VmError, WasmContractInfo,
 };
-use alloc::collections::{BTreeMap, VecDeque};
+use alloc::{
+    collections::{BTreeMap, VecDeque},
+    string::String,
+    vec,
+    vec::Vec,
+};
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use cosmwasm_std::{BlockInfo, Coin, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};

--- a/vm-wasmi/Cargo.toml
+++ b/vm-wasmi/Cargo.toml
@@ -20,8 +20,8 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 either = { version = "1.8", default-features = false }
 log = { version = "0.4", default-features = false }
-wasmi = { version = "0.22", default-features = false }
-wasmi-validation = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b", default-features = false }
+wasmi = { version = "0.26", default-features = false }
+wasmi-validation = { version = "0.5", default-features = false }
 wasm-instrument = { version = "0.2", default-features = false }
 cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "34af48221c90e6818fe341d6d5b15116dfeab671", default-features = false, features = [
   "iterator",

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -29,8 +29,7 @@ use cosmwasm_vm::{
     vm::{VMBase, VmErrorOf, VmGas, VmQueryCustomOf},
 };
 use wasmi::{
-    core::Value as RuntimeValue, AsContextMut, Engine, Extern, Instance, Linker, Memory, Module,
-    Store,
+    AsContextMut, Engine, Extern, Instance, Linker, Memory, Module, Store, Value as RuntimeValue,
 };
 
 /// A wasmi module reference
@@ -97,7 +96,7 @@ where
         WasmiOutput(WasmiFunctionResult(values), _): WasmiOutput<WasmiVM<V, S>>,
     ) -> Result<Self, Self::Error> {
         match values.as_slice() {
-            &[run_val] => Ok(run_val),
+            [ref run_val] => Ok(run_val.clone()),
             _ => Err(WasmiVMError::UnexpectedReturnType.into()),
         }
     }


### PR DESCRIPTION
- Upgrade wasmi version to `0.26`
- `no_std` support in orchestrate