### PR TITLE
Don’t use VecDeque unnecessarily

### DIFF
--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -898,17 +898,17 @@ impl<'a, CH: CustomHandler, AH: AddressHandler> Has<MessageInfo> for Context<'a,
 impl<'a, CH: CustomHandler, AH: AddressHandler> Transactional for Context<'a, CH, AH> {
     type Error = VmError;
     fn transaction_begin(&mut self) -> Result<(), Self::Error> {
-        self.state.transactions.push_back(self.state.db.clone());
+        self.state.transactions.push(self.state.db.clone());
         log::debug!("> Transaction begin: {}", self.state.transactions.len());
         Ok(())
     }
     fn transaction_commit(&mut self) -> Result<(), Self::Error> {
-        let _ = self.state.transactions.pop_back().expect("impossible");
+        let _ = self.state.transactions.pop().expect("impossible");
         log::debug!("< Transaction commit: {}", self.state.transactions.len());
         Ok(())
     }
     fn transaction_rollback(&mut self) -> Result<(), Self::Error> {
-        self.state.db = self.state.transactions.pop_back().expect("impossible");
+        self.state.db = self.state.transactions.pop().expect("impossible");
         log::debug!("< Transaction abort: {}", self.state.transactions.len());
         Ok(())
     }

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -3,12 +3,7 @@ use super::{
     Account, AddressHandler, Context, CustomHandler, Db, ExecutionType, Gas, IbcChannelId,
     IbcState, VmError, WasmContractInfo,
 };
-use alloc::{
-    collections::{BTreeMap, VecDeque},
-    string::String,
-    vec,
-    vec::Vec,
-};
+use alloc::collections::BTreeMap;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use cosmwasm_std::{BlockInfo, Coin, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};
@@ -114,7 +109,7 @@ where
 
 #[derive(Clone)]
 pub struct State<CH, AH> {
-    pub transactions: VecDeque<Db<CH>>,
+    pub transactions: Vec<Db<CH>>,
     pub db: Db<CH>,
     pub codes: BTreeMap<CosmwasmCodeId, (Vec<u8>, Vec<u8>)>,
     pub gas: Gas,
@@ -363,7 +358,7 @@ impl<CH: CustomHandler, AH: AddressHandler> State<CH, AH> {
                 custom_handler,
                 ..Default::default()
             },
-            transactions: VecDeque::default(),
+            transactions: Default::default(),
             call_depth: 0,
             _marker: PhantomData,
         }


### PR DESCRIPTION
State::transactions is used as a stack (where elements are pushed to and popped from the back).  It’s therefore unnecessary to use VecDeque for the list.  Vec is entirely sufficient.