### PR TITLE
orchestrate: zero call_depth when creating a sub VM

### DIFF
--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -206,6 +206,7 @@ pub struct Context<'a, CH: CustomHandler, AH: AddressHandler> {
     pub env: Env,
     pub info: MessageInfo,
     pub state: &'a mut State<CH, AH>,
+    call_depth: u32,
 }
 
 impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiContext for Context<'a, CH, AH> {
@@ -218,7 +219,7 @@ impl<'a, CH: CustomHandler, AH: AddressHandler> WasmiContext for Context<'a, CH,
     }
 
     fn call_depth_mut(&mut self) -> &mut u32 {
-        &mut self.state.call_depth
+        &mut self.call_depth
     }
 }
 
@@ -263,6 +264,7 @@ impl<'a, CH: CustomHandler, AH: AddressHandler> Context<'a, CH, AH> {
                     funds,
                 },
                 state: self.state,
+                call_depth: 0,
             },
         )?;
         Ok(f(&mut sub_vm))

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -113,7 +113,6 @@ pub struct State<CH, AH> {
     pub db: Db<CH>,
     pub codes: BTreeMap<CosmwasmCodeId, (Vec<u8>, Vec<u8>)>,
     pub gas: Gas,
-    pub call_depth: u32,
     _marker: PhantomData<AH>,
 }
 
@@ -359,7 +358,6 @@ impl<CH: CustomHandler, AH: AddressHandler> State<CH, AH> {
                 ..Default::default()
             },
             transactions: Default::default(),
-            call_depth: 0,
             _marker: PhantomData,
         }
     }
@@ -395,6 +393,7 @@ fn create_vm<CH: CustomHandler, AH: AddressHandler>(
             env,
             info,
             state: extension,
+            call_depth: 0,
         },
     )
     .unwrap()


### PR DESCRIPTION
Because a) State is shared between all VM’s within a single execution chain and b) call depth is tracked inside of State, recursive queries (for example) count towards the call depth.  This is however not desired since intention of call_depth is to track calls into the WASM code only within a single VM.

Move the call_depth field out of State directly to Context which gets reinitialised each time a sub-VM is created.