### PR TITLE
Update install-nix-action in build.yaml and stop testing on Mac

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
   build-tests-clippy-fmt:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: |


### PR DESCRIPTION
The build-tests-clippy-fmt workflow fails on MacOS due to SIP:

    Could not set environment: 150: Operation not permitted while
    System Integrity Protection is engaged

This commit takes the lazy route and removes MacOS testing from
workflow configuration.  Running the tests on Ubuntu should be
sufficient for our needs.
