### PR TITLE
Prefer ToString::to_string over format!

### DIFF
--- a/orchestrate/src/ibc.rs
+++ b/orchestrate/src/ibc.rs
@@ -2,7 +2,7 @@ use crate::{
     vm::{Account, AddressHandler, Context, CustomHandler, IbcState, State, VmError},
     Api as IApi, Direct, Dispatch,
 };
-use alloc::{format, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use cosmwasm_std::{
     Binary, Env, Event, Ibc3ChannelOpenResponse, IbcAcknowledgement, IbcChannel,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcEndpoint, IbcOrder, IbcPacketAckMsg,
@@ -117,11 +117,11 @@ impl<'a, CH: CustomHandler, AH: AddressHandler> IbcNetwork<'a, CH, AH> {
         let contract_counterparty = Account::try_from(env_counterparty.contract.address.clone())?;
         let mut channel = IbcChannel::new(
             IbcEndpoint {
-                port_id: format!("{contract}"),
+                port_id: contract.to_string(),
                 channel_id: channel_id.clone(),
             },
             IbcEndpoint {
-                port_id: format!("{contract_counterparty}"),
+                port_id: contract_counterparty.to_string(),
                 channel_id: channel_id.clone(),
             },
             channel_ordering,

--- a/orchestrate/src/vm/error.rs
+++ b/orchestrate/src/vm/error.rs
@@ -1,5 +1,5 @@
 use super::{bank, Account};
-use alloc::{format, string::String};
+use alloc::string::String;
 use core::fmt::Display;
 use cosmwasm_vm::{
     executor::ExecutorError,
@@ -44,10 +44,10 @@ impl From<wasmi::Error> for VmError {
                 if let Some(err) = trap.downcast_ref::<VmError>() {
                     err.clone()
                 } else {
-                    Self::Interpreter(format!("{e}"))
+                    Self::Interpreter(e.to_string())
                 }
             }
-            e => Self::Interpreter(format!("{e}")),
+            e => Self::Interpreter(e.to_string()),
         }
     }
 }

--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -11,7 +11,7 @@ pub use state::*;
 
 use super::ExecutionType;
 use alloc::collections::BTreeMap;
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{string::String, vec, vec::Vec};
 use bank::Bank;
 use core::{fmt::Debug, num::NonZeroU32};
 use cosmwasm_std::{
@@ -542,9 +542,9 @@ impl<'a, CH: CustomHandler, AH: AddressHandler> VMBase for Context<'a, CH, AH> {
         contract_info_response.admin = contract_info.admin.clone().map(Into::into);
         contract_info_response.creator = contract_info.instantiator.clone().into();
 
-        let ibc_port_id = format!("{contract_address}");
+        let ibc_port_id = contract_address.to_string();
         if self.state.db.ibc.contains_key(&ibc_port_id) {
-            contract_info_response.ibc_port = Some(format!("{contract_address}"));
+            contract_info_response.ibc_port = Some(ibc_port_id);
         }
 
         Ok(contract_info_response)

--- a/orchestrate/tests/crypto_verify.rs
+++ b/orchestrate/tests/crypto_verify.rs
@@ -392,15 +392,15 @@ fn tendermint_signatures_batch_verify_works() {
 
     let messages: Vec<_> = [ED25519_MESSAGE_HEX, ED25519_MESSAGE2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     let signatures: Vec<_> = [ED25519_SIGNATURE_HEX, ED25519_SIGNATURE2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     let public_keys: Vec<_> = [ED25519_PUBLIC_KEY_HEX, ED25519_PUBLIC_KEY2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
 
     let verify_msg = format!(
@@ -431,17 +431,17 @@ fn tendermint_signatures_batch_verify_message_multisig_works() {
     // One message
     let messages: Vec<_> = [ED25519_MESSAGE_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     // Multiple signatures
     let signatures: Vec<_> = [ED25519_SIGNATURE_HEX, ED25519_SIGNATURE_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     // Multiple pubkeys
     let public_keys: Vec<_> = [ED25519_PUBLIC_KEY_HEX, ED25519_PUBLIC_KEY_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
 
     let verify_msg = format!(
@@ -473,17 +473,17 @@ fn tendermint_signatures_batch_verify_single_public_key_works() {
     //FIXME: Use different messages / signatures
     let messages: Vec<_> = [ED25519_MESSAGE_HEX, ED25519_MESSAGE_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     // Multiple signatures
     let signatures: Vec<_> = [ED25519_SIGNATURE_HEX, ED25519_SIGNATURE_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     // One pubkey
     let public_keys: Vec<_> = [ED25519_PUBLIC_KEY_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
 
     let verify_msg = format!(
@@ -513,15 +513,15 @@ fn tendermint_signatures_batch_verify_fails() {
 
     let messages: Vec<_> = ["1234", ED25519_MESSAGE2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     let signatures: Vec<_> = [ED25519_SIGNATURE_HEX, ED25519_SIGNATURE2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
     let public_keys: Vec<_> = [ED25519_PUBLIC_KEY_HEX, ED25519_PUBLIC_KEY2_HEX]
         .iter()
-        .map(|m| format!("{}", Binary(hex::decode(m).unwrap())))
+        .map(|m| Binary(hex::decode(m).unwrap()).to_string())
         .collect();
 
     let verify_msg = format!(

--- a/research/bin/research.rs
+++ b/research/bin/research.rs
@@ -11,7 +11,6 @@ use cosmwasm_vm::vm::VMBase;
 
 use alloc::{
     collections::BTreeMap,
-    format,
     string::{String, ToString},
     vec,
     vec::Vec,
@@ -832,7 +831,7 @@ impl TryFrom<String> for BankAccount {
 
 impl From<BankAccount> for Addr {
     fn from(BankAccount(account): BankAccount) -> Self {
-        Addr::unchecked(format!("{account}"))
+        Addr::unchecked(account.to_string())
     }
 }
 

--- a/vm-wasmi/src/host_functions.rs
+++ b/vm-wasmi/src/host_functions.rs
@@ -4,7 +4,7 @@
     clippy::cast_sign_loss
 )]
 use super::{
-    format, AsContextMut, String, Tagged, VMBase, Vec, VmErrorOf, VmGas, VmQueryCustomOf,
+    AsContextMut, String, Tagged, ToString, VMBase, Vec, VmErrorOf, VmGas, VmQueryCustomOf,
     WasmiBaseVM, WasmiVM,
 };
 
@@ -164,7 +164,7 @@ where
         Ok(address) => address,
         Err(e) => {
             let Tagged(value_pointer, _) =
-                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, format!("{e}").as_bytes())?;
+                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, e.to_string().as_bytes())?;
             return Ok(value_pointer as i32);
         }
     };
@@ -173,7 +173,7 @@ where
         Ok(_) => Ok(0),
         Err(e) => {
             let Tagged(value_pointer, _) =
-                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, format!("{e}").as_bytes())?;
+                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, e.to_string().as_bytes())?;
             Ok(value_pointer as i32)
         }
     }
@@ -203,7 +203,7 @@ where
         Ok(address) => address,
         Err(e) => {
             let Tagged(value_pointer, _) =
-                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, format!("{e}").as_bytes())?;
+                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, e.to_string().as_bytes())?;
             return Ok(value_pointer as i32);
         }
     };
@@ -219,7 +219,7 @@ where
         }
         Err(e) => {
             let Tagged(value_pointer, _) =
-                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, format!("{e}").as_bytes())?;
+                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, e.to_string().as_bytes())?;
             Ok(value_pointer as i32)
         }
     }
@@ -257,7 +257,7 @@ where
         }
         Err(e) => {
             let Tagged(value_pointer, _) =
-                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, format!("{e}").as_bytes())?;
+                passthrough_in::<WasmiVM<V, S>, ()>(&mut vm, e.to_string().as_bytes())?;
             Ok(value_pointer as i32)
         }
     }

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -20,7 +20,11 @@ pub use vm::*;
 #[cfg(test)]
 mod semantic;
 
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use core::marker::PhantomData;
 use cosmwasm_vm::{
     executor::{

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -829,7 +829,7 @@ impl TryFrom<String> for BankAccount {
 
 impl From<BankAccount> for Addr {
     fn from(BankAccount(account): BankAccount) -> Self {
-        Addr::unchecked(format!("{account}"))
+        Addr::unchecked(account.to_string())
     }
 }
 

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -22,7 +22,13 @@ use crate::{
         VmQueryCustomOf, VM,
     },
 };
-use alloc::{fmt::Display, format, string::String, vec, vec::Vec};
+use alloc::{
+    fmt::Display,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use core::fmt::Debug;
 use cosmwasm_std::{
     Addr, AllBalanceResponse, Attribute, BalanceResponse, BankMsg, BankQuery, Binary,
@@ -133,7 +139,7 @@ impl Display for SystemEventType {
 
 impl From<SystemEvent> for Event {
     fn from(sys_event: SystemEvent) -> Self {
-        Event::new(format!("{}", sys_event.ty)).add_attributes(
+        Event::new(sys_event.ty.to_string()).add_attributes(
             sys_event
                 .attributes
                 .into_iter()
@@ -250,7 +256,7 @@ where
                 addr_attr,
                 SystemAttribute {
                     key: SystemAttributeKey::CodeID,
-                    value: format!("{code_id}"),
+                    value: code_id.to_string(),
                 },
             ]
         } else {


### PR DESCRIPTION
Rust is currently unable to optimise `format!("{x}")` invocations
which are noticeably slower than `x.to_string()` calls.  Prefer the
latter.
